### PR TITLE
keyword 更新，修复已知问题

### DIFF
--- a/keyword.py
+++ b/keyword.py
@@ -141,7 +141,10 @@ async def send_reply(chat_id, reply_msg, context):
                 replace_data["last_name"] = sender.last_name if sender.last_name else ""
             if chat:
                 replace_data["chat_id"] = chat.id
-                replace_data["chat_name"] = chat.title
+                last_name = chat.last_name
+                if not last_name:
+                    last_name = ""
+                replace_data["chat_name"] = f"{chat.first_name} {last_name}"
         update_last_time = False
         could_send_msg = valid_time(chat_id)
         for re_type, re_msg in reply_msg:
@@ -576,6 +579,8 @@ async def auto_reply(context):
         elif g_list or n_list:
             user_list = g_list if g_list else n_list
         send_text = context.text
+        if not send_text:
+            send_text = ""
         for k, v in plain_dict.items():
             if k in send_text:
                 tmp = get_redis(f"keyword.{chat_id}.single.plain.{encode(k)}")

--- a/list.json
+++ b/list.json
@@ -362,7 +362,7 @@
         },
         {
             "name": "keyword",
-            "version": "2.22",
+            "version": "2.23",
             "section": "chat",
             "maintainer": "c3b2a",
             "size": "24.8 kb",


### PR DESCRIPTION
问题一、当发送消息不包含文字时，发送不成功。
问题二、修复在私人聊天中的 replace_data["chat_name"] 原来的 chat.title 产生的报错。